### PR TITLE
HTU21D_test compiler warning cleanup.

### DIFF
--- a/HTU21D/c/HTU21D_test.c
+++ b/HTU21D/c/HTU21D_test.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
+#include "wiringPi.h"
+#include "wiringPiI2C.h"
+
 
 #include "HTU21D.h"
 

--- a/HTU21D/c/Makefile
+++ b/HTU21D/c/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-I.
+CFLAGS=-I. -Wall
 DEPS = 
 OBJ = HTU21D.o HTU21D_test.o
 EXTRA_LIBS=-lwiringPi


### PR DESCRIPTION
Added -Wall to compile command and added headers to HTU21D_test.c to address the resulting warnings.

Thanks for the example code!